### PR TITLE
fix more globals usage, add some tests

### DIFF
--- a/reader/manifest/manifest.go
+++ b/reader/manifest/manifest.go
@@ -3,26 +3,30 @@ package manifest
 import (
 	"encoding/json"
 	"io/ioutil"
-	"strings"
 
 	"github.com/pkg/errors"
 )
 
 // Read webpack-manifest-plugin format manifest
 func Read(path string) (map[string][]string, error) {
-	assets := make(map[string][]string, 0)
 	data, err := ioutil.ReadFile(path + "/manifest.json")
 	if err != nil {
-		return assets, errors.Wrap(err, "go-webpack: Error when loading manifest from file")
+		return nil, errors.Wrap(err, "go-webpack: Error when loading manifest from file")
 	}
 
+	return unmarshalManifest(data)
+}
+
+func unmarshalManifest(data []byte) (map[string][]string, error) {
 	response := make(map[string]string, 0)
-	json.Unmarshal(data, &response)
+	err := json.Unmarshal(data, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, "go-webpack: Error unmarshaling manifest file")
+	}
+
+	assets := make(map[string][]string, len(response))
 	for key, value := range response {
-		//log.Println("found asset", key, value)
-		if !strings.Contains(value, ".map") {
-			assets[key] = []string{value}
-		}
+		assets[key] = []string{value}
 	}
 	return assets, nil
 }

--- a/reader/manifest/manifest_test.go
+++ b/reader/manifest/manifest_test.go
@@ -1,0 +1,17 @@
+package manifest
+
+import "testing"
+
+func TestValidManifest(t *testing.T) {
+	validManifest := `
+	{
+		"site.js": "site.12345.js",
+		"site2.js": "site2.12346.js"
+	}
+	`;
+
+	_, err := unmarshalManifest([]byte(validManifest))
+	if err != nil {
+		t.Fatalf("shouldn't fail to unmarshal a valid manifest json");
+	}
+}

--- a/webpack.go
+++ b/webpack.go
@@ -28,10 +28,6 @@ var IgnoreMissing = true
 // Verbose error messages to console (even if error is ignored)
 var Verbose = true
 
-var isDev = false
-var initDone = false
-var preloadedAssets map[string][]string
-
 type Config struct {
 	// DevHost webpack-dev-server host:port
 	DevHost string
@@ -47,23 +43,20 @@ type Config struct {
 	Verbose bool
 	// IsDev - true to use webpack-serve or webpack-dev-server, false to use filesystem and manifest.json
 	IsDev bool
-
-	initDone        bool
-	preloadedAssets map[string][]string
 }
 
 var AssetHelper func(string) (template.HTML, error)
 
 // Init Set current environment and preload manifest
-func Init(dev bool) {
+func Init(dev bool) error {
 	if Plugin == "deprecated-stats" {
 		Plugin = "stats"
 		log.Println("go-webpack: default plugin will be changed to manifest instead of stats-plugin")
 		log.Println("go-webpack: to continue using stats-plugin, please set webpack.Plugin = 'stats' explicitly")
 	}
-	isDev = dev
 
-	AssetHelper = GetAssetHelper(&Config{
+	var err error
+	AssetHelper, err = GetAssetHelper(&Config{
 		DevHost:       DevHost,
 		FsPath:        FsPath,
 		WebPath:       WebPath,
@@ -72,6 +65,7 @@ func Init(dev bool) {
 		Verbose:       Verbose,
 		IsDev:         dev,
 	})
+	return err
 }
 
 func BasicConfig(host, path, webPath string) *Config {
@@ -82,7 +76,7 @@ func BasicConfig(host, path, webPath string) *Config {
 		Plugin:        "manifest",
 		IgnoreMissing: true,
 		Verbose:       true,
-		IsDev:         isDev,
+		IsDev:         false,
 	}
 }
 
@@ -92,28 +86,29 @@ func readManifest(conf *Config) (map[string][]string, error) {
 	return reader.Read(conf.Plugin, conf.DevHost, conf.FsPath, conf.WebPath, conf.IsDev)
 }
 
-func GetAssetHelper(conf *Config) func(string) (template.HTML, error) {
+func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
+	preloadedAssets := map[string][]string{}
+
 	var err error
 	if conf.IsDev {
 		// Try to preload manifest, so we can show an error if webpack-dev-server is not running
 		_, err = readManifest(conf)
+		if err != nil {
+			log.Println(err)
+		}
 	} else {
-		conf.preloadedAssets, err = readManifest(conf)
+		preloadedAssets, err = readManifest(conf)
+		// we won't ever re-check assets in this case.  this should be a hard error.
+		if err != nil {
+			return nil, err
+		}
 	}
-	if err != nil {
-		log.Println(err)
-	}
-	initDone = true
 
 	return func(key string) (template.HTML, error) {
 		var err error
 
-		if !initDone {
-			return "", errors.New("Please call webpack.Init() first (see readme)")
-		}
-
 		var assets map[string][]string
-		if isDev {
+		if conf.IsDev {
 			assets, err = readManifest(conf)
 			if err != nil {
 				return template.HTML(""), err
@@ -150,5 +145,5 @@ func GetAssetHelper(conf *Config) func(string) (template.HTML, error) {
 			}
 		}
 		return template.HTML(strings.Join(buf, "\n")), nil
-	}
+	}, nil
 }

--- a/webpack.go
+++ b/webpack.go
@@ -104,6 +104,10 @@ func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
 		}
 	}
 
+	return createAssetHelper(conf, preloadedAssets), nil
+}
+
+func createAssetHelper(conf *Config, preloadedAssets map[string][]string) func(string) (template.HTML, error) {
 	return func(key string) (template.HTML, error) {
 		var err error
 
@@ -124,13 +128,13 @@ func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
 		v, ok := assets[key]
 		if !ok {
 			message := "go-webpack: Asset file '" + key + "' not found in manifest"
-			if Verbose {
+			if conf.Verbose {
 				log.Printf("%s. Manifest contents:", message)
 				for k, a := range assets {
 					log.Printf("%s: %s", k, a)
 				}
 			}
-			if IgnoreMissing {
+			if conf.IgnoreMissing {
 				return template.HTML(""), nil
 			}
 			return template.HTML(""), errors.New(message)
@@ -145,5 +149,5 @@ func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
 			}
 		}
 		return template.HTML(strings.Join(buf, "\n")), nil
-	}, nil
+	}
 }

--- a/webpack_test.go
+++ b/webpack_test.go
@@ -1,0 +1,34 @@
+package webpack
+
+import (
+	"testing"
+)
+
+
+func TestManifestAssetHelper(t *testing.T) {
+	assets := map[string][]string{
+		"main.js": []string{"main.1.js", "main.2.js"},
+	}
+
+	helper := createAssetHelper(&Config{
+		Plugin: "manifest",
+	}, assets)
+
+	html, err := helper("main.js")
+	if err != nil {
+		t.Fatalf("error %v returned from asset helper for valid asset", err)
+	}
+	expectedHTML :=
+`<script type="text/javascript" src="main.1.js"></script>
+<script type="text/javascript" src="main.2.js"></script>`;
+
+	if string(html) != expectedHTML {
+		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
+	// IgnoreMissing = false
+	_, err = helper("maiin.js")
+	if err == nil {
+		t.Fatalf("error nil when it shouldn't have been")
+	}
+}


### PR DESCRIPTION
There were a few variables still being written to `Config` but read from globals.

Added some basic tests for a couple of codepaths, and also made more things return errors (including `Init`, so the !dev case would fail if it failed to parse the manifest.)